### PR TITLE
Update parser.py

### DIFF
--- a/src/ifcfg/parser.py
+++ b/src/ifcfg/parser.py
@@ -209,7 +209,7 @@ class UnixParser(Parser):
     @classmethod
     def get_patterns(cls):
         return [
-            '(?P<device>^[a-zA-Z0-9]+): flags=(?P<flags>.*) mtu (?P<mtu>.*)',
+            '(?P<device>^[a-zA-Z0-9:]+): flags=(?P<flags>.*) mtu (?P<mtu>.*)',
             '.*inet\s+(?P<inet>[\d\.]+).*',
             '.*inet6\s+(?P<inet6>[\d\:abcdef]+).*',
             '.*broadcast (?P<broadcast>[^\s]*).*',
@@ -258,7 +258,7 @@ class LinuxParser(UnixParser):
     @classmethod
     def get_patterns(cls):
         return super(LinuxParser, cls).get_patterns() + [
-            '(?P<device>^[a-zA-Z0-9:]+)(.*)Link encap:(.*).*',
+            '(?P<device>^[a-zA-Z0-9:_-]+)(.*)Link encap:(.*).*',
             '(.*)Link encap:(.*)(HWaddr )(?P<ether>[^\s]*).*',
             '.*(inet addr:\s*)(?P<inet>[^\s]+).*',
             '.*(inet6 addr:\s*)(?P<inet6>[^\s\/]+)',


### PR DESCRIPTION
Two changes for regex patterns:
- on Ubuntu at least, semicolon ':' is used for alias interfaces, 
e.g. enp0s20u1:1: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500

- on BusyBox embedded Linux, we use '_' and '-' for our interface names
e.g. br-wan    Link encap:Ethernet  HWaddr 11:22:dd:22:66:11