### PR TITLE
Fetch command outputs as string, then encode as UTF-8 if non-unicode system

### DIFF
--- a/src/ifcfg/tools.py
+++ b/src/ifcfg/tools.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import locale
 import logging
 import os
 from subprocess import PIPE, Popen
@@ -21,11 +22,15 @@ def minimal_logger(name):
     return log
 
 def exec_cmd(cmd_args):
-    proc = Popen(cmd_args, stdout=PIPE, stderr=PIPE, shell=True)
-    (stdout, stderr) = proc.communicate()
+    # Using `shell=True` because commands may be scripts
+    # Using `universal_newlines=True` because we want string output, not bytes
+    proc = Popen(cmd_args, stdout=PIPE, stderr=PIPE, universal_newlines=True, shell=True)
+    stdout, stderr = proc.communicate()
     proc.wait()
-    stdout = stdout.decode("utf-8")
-    stderr = stderr.decode("utf-8")
+    # If we aren't using UTF-8 on this system, then re-encode the string.
+    if locale.getpreferredencoding().lower() != "utf-8":
+        stdout = stdout.decode(locale.getpreferredencoding()).encode('utf-8')
+        stderr = stderr.decode(locale.getpreferredencoding()).encode('utf-8')
     return (stdout, stderr, proc.returncode)
 
 def hex2dotted(hex_num):

--- a/tests/tools_tests.py
+++ b/tests/tools_tests.py
@@ -1,7 +1,9 @@
 """Tests for ifcfg.tools."""
 
+import locale
 import logging
 import os
+import sys
 import unittest
 
 import ifcfg
@@ -20,3 +22,13 @@ class IfcfgToolsTestCase(unittest.TestCase):
     def test_command(self):
         output, __, __ = exec_cmd("echo -n 'this is a test'")
         self.assertEqual(output, "this is a test")
+
+
+    @unittest.skipIf(sys.version[0] != '2',
+                     "Python 2 only supports non-unicode stuff")
+    def test_command_non_unicode(self):
+        getpreferredencoding_orig = locale.getpreferredencoding
+        locale.getpreferredencoding = lambda: "ISO-8859-1"
+        output, __, __ = exec_cmd("echo -n 'this is a test'")
+        self.assertEqual(output, "this is a test")
+        locale.getpreferredencoding = getpreferredencoding_orig


### PR DESCRIPTION
This should fix reported `UnicodeDecodeError` in https://github.com/learningequality/kolibri/pull/1929